### PR TITLE
Remove spurious `,`. Also edit source url

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,8 +4,8 @@
     "author"      : "Uladox <uladoxiental@gmail.com>",
     "description" : "Uggh I need to edit a text file in some copy paste way...wait, perl modules!",
     "depends"     : [ "File::Temp" ],
-    "source-url"  : "https://github.com/Uladox/Editscr-Uggedit",
+    "source-url"  : "git://github.com/Uladox/Editscr-Uggedit.git",
     "provides"    : {
-        "Editsrc::Uggedit" : "lib/Editsrc/Uggedit.pm",
+        "Editsrc::Uggedit" : "lib/Editsrc/Uggedit.pm"
      }
 }


### PR DESCRIPTION
Removed comma, for JSON::Tiny fussiness, e.g.:

```
% cd Editscr-Uggedit
% panda installdeps .
Unable to parse expression in object; couldn't find final '}' 
  in regex object at lib/JSON/Tiny/Grammar.pm:5
  in regex value:sym<object> at lib/JSON/Tiny/Grammar.pm:21
  in regex value at lib/JSON/Tiny/Grammar.pm:11
...
```

I'm also tweaked the source url. I think it needs to be as above.
