### PR TITLE
Replace `done` with `done-testing`

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -27,4 +27,4 @@ use Editsrc::Uggedit;
       'Able to run perl 6 code';
 }
 
-done;
+done-testing;

--- a/t/multilang.t
+++ b/t/multilang.t
@@ -16,4 +16,4 @@ use Editsrc::Uggedit;
       'Can run code';
 }
 
-done;
+done-testing;


### PR DESCRIPTION
As of perl6 version 6.c the `done` command in the test module has been
replaced by the `done-testing` command.  This commit corrects the test files
and allows the test suite to run again.
