### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name"        : "Editsrc::Uggedit",
+    "license"     : "Artistic-2.0",
     "version"     : "*",
     "author"      : "Uladox <uladoxiental@gmail.com>",
     "description" : "Uggh I need to edit a text file in some copy paste way...wait, perl modules!",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license